### PR TITLE
Migrate to native go EC arithmetic lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,11 @@ go 1.17
 require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 	github.com/ethereum/go-ethereum v1.10.16
-	github.com/renproject/secp256k1 v0.0.0-20220707021023-f849b5f8a3c6
 	github.com/stretchr/testify v1.7.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/renproject/surge v1.2.3 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/secp256k1/adaptor.go
+++ b/secp256k1/adaptor.go
@@ -3,31 +3,29 @@ package secp256k1
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
-	"github.com/renproject/secp256k1"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
 type EncryptedSignature struct {
-	R, R_a *secp256k1.Point
-	s      *secp256k1.Fn
+	R, R_a *Point
+	s      *secp256k1.ModNScalar
 	proof  *dleqProof
 }
 
-func (a *EncryptedSignature) Decrypt(sk *secp256k1.Fn) (*Signature, error) {
-	y_inv := &secp256k1.Fn{}
-	y_inv.Inverse(sk)
-	s := &secp256k1.Fn{}
-	s.Mul(a.s, y_inv)
+func (a *EncryptedSignature) Decrypt(sk *secp256k1.ModNScalar) (*Signature, error) {
+	y_inv := &secp256k1.ModNScalar{}
+	y_inv.InverseValNonConst(sk)
+	s := new(secp256k1.ModNScalar)
+	s.Mul2(a.s, y_inv)
 
 	// negate s if high
-	if s.IsHigh() {
-		s.Negate(s)
+	if s.IsOverHalfOrder() {
+		s.Negate()
 	}
 
-	r, _, err := a.R.XY()
-	if err != nil {
-		return nil, err
-	}
+	r := a.R.X
 
 	return &Signature{
 		r: &r,
@@ -41,9 +39,9 @@ func (s *EncryptedSignature) Encode() ([]byte, error) {
 	var b [encodedAdaptorSize]byte
 	s.R.PutBytes(b[:33])
 	s.R_a.PutBytes(b[33:66])
-	s.s.PutB32(b[66:98])
-	s.proof.z.PutB32(b[98 : 98+32])
-	s.proof.s.PutB32(b[98+32:])
+	s.s.SetByteSlice(b[66:98])
+	s.proof.z.PutBytesUnchecked(b[98 : 98+32])
+	s.proof.s.PutBytesUnchecked(b[98+32:])
 	return b[:], nil
 }
 
@@ -71,30 +69,26 @@ func (s *EncryptedSignature) Decode(b []byte) error {
 	}
 
 	// parse adaptor
-	R := &secp256k1.Point{}
-	err := R.SetBytes(b[:33])
-	if err != nil {
+	R := new(Point)
+	if err := R.SetBytes(b[:33]); err != nil {
 		return err
 	}
-
 	b = b[33:]
-	R_a := &secp256k1.Point{}
-	err = R_a.SetBytes(b[:33])
-	if err != nil {
+	R_a := new(Point)
+	if err := R_a.SetBytes(b[:33]); err != nil {
 		return err
 	}
-
 	b = b[33:]
-	s_a := &secp256k1.Fn{}
-	s_a.SetB32(b[:32])
+	s_a := new(secp256k1.ModNScalar)
+	s_a.SetByteSlice(b[:32])
 	b = b[32:]
 
 	// parse proof
-	z := &secp256k1.Fn{}
-	z.SetB32(b[:32])
+	z := new(secp256k1.ModNScalar)
+	z.SetByteSlice((b[:32]))
 	b = b[32:]
-	s_p := &secp256k1.Fn{}
-	s_p.SetB32(b[:32])
+	s_p := new(secp256k1.ModNScalar)
+	s_p.SetByteSlice(b[:32])
 
 	s.s = s_a
 	s.R_a = R_a
@@ -108,15 +102,14 @@ func (s *EncryptedSignature) Decode(b []byte) error {
 	return nil
 }
 
-func (kp *Keypair) AdaptorSign(msg []byte, encKey *secp256k1.Point, nonceFnOpt ...NonceFunc) (*EncryptedSignature, error) {
+func (kp *Keypair) AdaptorSign(msg []byte, encKey *Point, nonceFnOpt ...NonceFunc) (*EncryptedSignature, error) {
 	Y := encKey
-	if len(msg) != MessageLength {
-		return nil, errors.New("invalid message length: not 32 byte hash")
-	}
 
 	// hash of message
-	z := &secp256k1.Fn{}
-	_ = z.SetB32(msg) // TODO: check overflow
+	z := new(secp256k1.ModNScalar)
+	if z.SetByteSlice(msg) {
+		return nil, fmt.Errorf("invalid message length: not 32 byte hash")
+	}
 
 	x := kp.Private().key
 
@@ -133,16 +126,16 @@ func (kp *Keypair) AdaptorSign(msg []byte, encKey *secp256k1.Point, nonceFnOpt .
 	}
 
 	// R_a = k*G
-	R_a := &secp256k1.Point{}
+	R_a := new(Point)
 	R_a.BaseExp(k)
 
 	// calculate R and R' inputs for dleqProve
 	// R' = k*Y
-	R := &secp256k1.Point{}
+	R := new(Point)
 	R.Scale(Y, k)
 
 	// r == x-coord of R
-	r_fp, _, err := R.XY()
+	r_fp := R.X
 	if err != nil {
 		return nil, err
 	}
@@ -150,14 +143,7 @@ func (kp *Keypair) AdaptorSign(msg []byte, encKey *secp256k1.Point, nonceFnOpt .
 	r := fpToFn(&r_fp)
 
 	// s' = (z + r'*x) * k^(-1)
-	rx := &secp256k1.Fn{}
-	rx.Mul(r, x)
-	sum := &secp256k1.Fn{}
-	sum.Add(z, rx)
-	kinv := &secp256k1.Fn{}
-	kinv.Inverse(k)
-	s := &secp256k1.Fn{}
-	s.Mul(sum, kinv)
+	s := z.Add(r.Mul(x)).Mul(k.InverseNonConst())
 
 	proof, err := dleqProve(k, R_a, R, Y)
 	if err != nil {
@@ -178,67 +164,61 @@ func (k *PublicKey) VerifyAdaptor(msg []byte, encryptionKey *PublicKey, adaptor 
 	}
 
 	// hash of message
-	z := &secp256k1.Fn{}
-	overflow := z.SetB32(msg) // TODO: check overflow
-	if overflow {
-		return false, errors.New("message overflow")
+	z := &secp256k1.ModNScalar{}
+	if z.SetByteSlice(msg) {
+		return false, fmt.Errorf("invalid message length: not 32 byte hash")
 	}
 
-	r, _, err := adaptor.R.XY()
-	if err != nil {
-		return false, err
-	}
+	r := adaptor.R.X
 
 	// check adaptor.proof.R == (z*G + r'*P) * s^(-1)
-	zG := &secp256k1.Point{}
+	zG := new(Point)
 	zG.BaseExp(z)
-	rP := &secp256k1.Point{}
+	rP := new(Point)
 	rP.Scale(k.key, fpToFn(&r))
-	sum := &secp256k1.Point{}
+	sum := new(Point)
 	sum.Add(zG, rP)
-	sinv := &secp256k1.Fn{}
-	sinv.Inverse(adaptor.s)
-	R := &secp256k1.Point{}
-	R.Scale(sum, sinv)
+	s_inv := new(secp256k1.ModNScalar)
+	s_inv.InverseValNonConst(adaptor.s)
+	R := new(Point)
+	R.Scale(sum, s_inv)
 
-	if !R.Eq(adaptor.R_a) {
+	if !R.Equal(adaptor.R_a) {
 		return false, nil
 	}
 
 	return dleqVerify(encryptionKey, adaptor.proof, adaptor.R_a, adaptor.R), nil
 }
 
-func RecoverFromAdaptorAndSignature(adaptor *EncryptedSignature, encryptionKey *PublicKey, sig *Signature) (*secp256k1.Fn, error) {
+func RecoverFromAdaptorAndSignature(adaptor *EncryptedSignature, encryptionKey *PublicKey, sig *Signature) (*secp256k1.ModNScalar, error) {
 	// check sig.r == x-coordinate of R' = k*Y
 	r, _, err := adaptor.R.XY()
 	if err != nil {
 		return nil, err
 	}
 
-	if !r.Eq(sig.r) {
+	if !r.Equals(sig.r) {
 		return nil, errors.New("invalid signature for adaptor: r check failed")
 	}
 
 	// y' = s^-1 * s'
-	sinv := &secp256k1.Fn{}
-	sinv.Inverse(sig.s)
-	y := &secp256k1.Fn{}
-	y.Mul(sinv, adaptor.s)
+	s_inv := new(secp256k1.ModNScalar)
+	s_inv.InverseValNonConst(sig.s)
+	y := s_inv.Mul(adaptor.s)
 
-	Y := &secp256k1.Point{}
+	Y := new(Point)
 	Y.BaseExp(y)
 
 	// check Y' == Y, if so, return y'
-	if encryptionKey.key.Eq(Y) {
+	if encryptionKey.key.Equal(Y) {
 		return y, nil
 	}
 
 	// else if Y' == -Y, return -y'
-	negY := negatePoint(Y)
-	if encryptionKey.key.Eq(negY) {
-		yNeg := &secp256k1.Fn{}
-		yNeg.Negate(y)
-		return yNeg, nil
+	negY := Y.Copy()
+	negY.Negate()
+	if encryptionKey.key.Equal(negY) {
+		return y.Negate(), nil
 	}
 
 	return nil, errors.New("invalid signature for adaptor: y check failed")

--- a/secp256k1/adaptor_test.go
+++ b/secp256k1/adaptor_test.go
@@ -4,8 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/renproject/secp256k1"
-
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,7 +39,7 @@ func TestRecoverFromAdaptorAndSignature(t *testing.T) {
 	// TODO: fix this, doesn't work with signatures we generated
 	secret, err := RecoverFromAdaptorAndSignature(adaptor, oneTime.public, sig)
 	require.NoError(t, err)
-	require.True(t, secret.Eq(oneTime.private.key))
+	require.True(t, secret.Equals(oneTime.private.key))
 }
 
 func TestAdaptor_ValidPlain(t *testing.T) {
@@ -60,8 +59,8 @@ func TestAdaptor_ValidPlain(t *testing.T) {
 
 	decryptionKeyStr, err := hex.DecodeString("0b2aba63b885a0f0e96fa0f303920c7fb7431ddfa94376ad94d969fbf4109dc8")
 	require.NoError(t, err)
-	y := &secp256k1.Fn{}
-	y.SetB32(decryptionKeyStr)
+	y := new(secp256k1.ModNScalar)
+	y.SetByteSlice(decryptionKeyStr)
 
 	// verify ecdsa signature
 	signatureStr, err := hex.DecodeString("424d14a5471c048ab87b3b83f6085d125d5864249ae4297a57c84e74710bb67329e80e0ee60e57af3e625bbae1672b1ecaa58effe613426b024fa1621d903394")
@@ -78,7 +77,7 @@ func TestAdaptor_ValidPlain(t *testing.T) {
 	err = adaptor.Decode(adaptorStr)
 	require.NoError(t, err)
 
-	Y := &secp256k1.Point{}
+	Y := new(Point)
 	err = Y.SetBytes(encryptionkeyStr)
 	require.NoError(t, err)
 	encryptionKey := &PublicKey{
@@ -88,7 +87,7 @@ func TestAdaptor_ValidPlain(t *testing.T) {
 	// recover decryption key
 	secret, err := RecoverFromAdaptorAndSignature(adaptor, encryptionKey, sig)
 	require.NoError(t, err)
-	require.True(t, secret.Eq(y))
+	require.True(t, secret.Equals(y))
 
 	// TODO: dleq check fails, probably due to hash issues
 	// ok, err = pubkey.VerifyAdaptor(messageHashStr, encryptionKey, adaptor)

--- a/secp256k1/dleq.go
+++ b/secp256k1/dleq.go
@@ -38,7 +38,6 @@ func dleqProve(w *secp256k1.ModNScalar, R_a, R, Y *Point) (*dleqProof, error) {
 	Q_p.Scale(Y, k)
 
 	z := hashToScalar(R_a, Y, R, Q, Q_p)
-
 	s := w.Mul(z).Add(k)
 
 	return &dleqProof{

--- a/secp256k1/keys.go
+++ b/secp256k1/keys.go
@@ -156,20 +156,21 @@ func (s *Signature) UnmarshalJSON(in []byte) error {
 }
 
 func GenerateKeypair() *Keypair {
-	for {
-		if priv, err := secp256k1.GeneratePrivateKey(); err == nil {
-			pub := new(Point)
-			pub.BaseExp(&priv.Key)
+	priv, err := secp256k1.GeneratePrivateKey()
+	if err != nil {
+		panic(fmt.Errorf("expected key to generate, but got error: %e", err))
+	}
 
-			return &Keypair{
-				public: &PublicKey{
-					key: pub,
-				},
-				private: &PrivateKey{
-					key: &priv.Key,
-				},
-			}
-		}
+	pub := new(Point)
+	pub.BaseExp(&priv.Key)
+
+	return &Keypair{
+		public: &PublicKey{
+			key: pub,
+		},
+		private: &PrivateKey{
+			key: &priv.Key,
+		},
 	}
 }
 

--- a/secp256k1/keys.go
+++ b/secp256k1/keys.go
@@ -209,7 +209,7 @@ func sign(z, x *secp256k1.ModNScalar) (*Signature, error) {
 		return nil, err
 	}
 
-	kinv := &secp256k1.ModNScalar{}
+	kinv := new(secp256k1.ModNScalar)
 	kinv.InverseValNonConst(k)
 
 	// R = k*G
@@ -225,7 +225,7 @@ func sign(z, x *secp256k1.ModNScalar) (*Signature, error) {
 	r := fpToFn(r_fp)
 
 	// s = (z + r*x) * k^(-1)
-	s := r.Mul(x).Add(z).Add(kinv)
+	s := r.Mul(x).Add(z).Mul(kinv)
 
 	return &Signature{
 		r: r_fp,

--- a/secp256k1/nonce.go
+++ b/secp256k1/nonce.go
@@ -32,12 +32,6 @@ func WithRandom() NonceFunc {
 	}
 }
 
-func withHex(s string) NonceFunc {
-	return func() (*secp256k1.ModNScalar, error) {
-		return scalarFromHex(s), nil
-	}
-}
-
 func nonceRFC6979(sk *PrivateKey, msg []byte, extra []byte) (*secp256k1.ModNScalar, error) {
 	skBytes, err := sk.Encode()
 	if err != nil {

--- a/secp256k1/point.go
+++ b/secp256k1/point.go
@@ -1,6 +1,8 @@
 package secp256k1
 
 import (
+	"fmt"
+
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
@@ -31,7 +33,9 @@ func (p *Point) PutBytes(dst []byte) {
 }
 
 func (p *Point) XY() (*secp256k1.FieldVal, *secp256k1.FieldVal, error) {
-	// todo ensure not infinity
+	if p.X.IsZero() && p.Y.IsZero() {
+		return nil, nil, fmt.Errorf("point at infinity does not have valid coordinates")
+	}
 	return &p.X, &p.Y, nil
 }
 

--- a/secp256k1/point.go
+++ b/secp256k1/point.go
@@ -27,9 +27,7 @@ func (p *Point) ToBytes() []byte {
 func (p *Point) PutBytes(dst []byte) {
 	bs := secp256k1.NewPublicKey(&p.X, &p.Y).
 		SerializeCompressed()
-	for i := range bs {
-		dst[i] = bs[i]
-	}
+	copy(dst, bs)
 }
 
 func (p *Point) XY() (*secp256k1.FieldVal, *secp256k1.FieldVal, error) {

--- a/secp256k1/point.go
+++ b/secp256k1/point.go
@@ -1,0 +1,81 @@
+package secp256k1
+
+import (
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	old "github.com/renproject/secp256k1"
+)
+
+type Point struct {
+	*secp256k1.JacobianPoint
+	to_remove *old.Point
+}
+
+func (p *Point) SetBytes(bc []byte) error {
+	pk, err := secp256k1.ParsePubKey(bc)
+	if err != nil {
+		return err
+	}
+
+	p.JacobianPoint = &secp256k1.JacobianPoint{}
+	pk.AsJacobian(p.JacobianPoint)
+	return nil
+}
+
+func (p *Point) ToBytes() []byte {
+	return secp256k1.NewPublicKey(&p.X, &p.Y).
+		SerializeCompressed()
+}
+
+func (p *Point) PutBytes(dst []byte) {
+	bs := secp256k1.NewPublicKey(&p.X, &p.Y).
+		SerializeCompressed()
+	for i := range bs {
+		dst[i] = bs[i]
+	}
+}
+
+func (p *Point) XY() (*secp256k1.FieldVal, *secp256k1.FieldVal, error) {
+	// todo ensure not infinity
+	return &p.X, &p.Y, nil
+}
+
+func (p *Point) BaseExp(k *secp256k1.ModNScalar) {
+	p.JacobianPoint = &secp256k1.JacobianPoint{}
+	secp256k1.ScalarBaseMultNonConst(k, p.JacobianPoint)
+}
+
+func (p *Point) Scale(point *Point, k *secp256k1.ModNScalar) {
+	p.JacobianPoint = &secp256k1.JacobianPoint{}
+	secp256k1.ScalarMultNonConst(k, point.JacobianPoint, p.JacobianPoint)
+}
+
+func (p *Point) Add(a, b *Point) {
+	secp256k1.AddNonConst(a.JacobianPoint, b.JacobianPoint, p.JacobianPoint)
+}
+
+func (p *Point) Sub(a, b *Point) {
+	bNeg := b.Copy()
+	bNeg.Negate()
+	p.Add(a, bNeg)
+}
+
+func (p *Point) Negate() {
+	negOne := new(secp256k1.ModNScalar).SetInt(1).Negate()
+
+	p.Scale(p, negOne)
+}
+
+func (p *Point) Equal(other *Point) bool {
+	return p.JacobianPoint.X.Equals(&other.X) &&
+		p.JacobianPoint.Y.Equals(&other.Y) &&
+		p.JacobianPoint.Z.Equals(&other.Z)
+}
+
+func (p *Point) Copy() *Point {
+	p2 := new(secp256k1.JacobianPoint)
+	p2.Set(p.JacobianPoint)
+	return &Point{
+		JacobianPoint: p2,
+		to_remove:     nil,
+	}
+}

--- a/secp256k1/utils.go
+++ b/secp256k1/utils.go
@@ -44,19 +44,3 @@ func scalarFromHex(s string) *secp256k1.ModNScalar {
 
 	return fn
 }
-
-func scalarToHex(fn *secp256k1.ModNScalar) string {
-	var b [32]byte
-	fn.PutBytes(&b)
-	return hex.EncodeToString(b[:])
-}
-
-func baseFieldToHex(fn *secp256k1.FieldVal) string {
-	var b [32]byte
-	fn.PutBytes(&b)
-	return hex.EncodeToString(b[:])
-}
-
-func pointToHex(p *Point) string {
-	return hex.EncodeToString(p.ToBytes())
-}

--- a/secp256k1/utils.go
+++ b/secp256k1/utils.go
@@ -44,3 +44,19 @@ func scalarFromHex(s string) *secp256k1.ModNScalar {
 
 	return fn
 }
+
+func scalarToHex(fn *secp256k1.ModNScalar) string {
+	var b [32]byte
+	fn.PutBytes(&b)
+	return hex.EncodeToString(b[:])
+}
+
+func baseFieldToHex(fn *secp256k1.FieldVal) string {
+	var b [32]byte
+	fn.PutBytes(&b)
+	return hex.EncodeToString(b[:])
+}
+
+func pointToHex(p *Point) string {
+	return hex.EncodeToString(p.ToBytes())
+}


### PR DESCRIPTION
Replace cgo-based [renproject/secp256k1](https://github.com/renproject/secp256k1) with go-native [decred/dcrd/secp256k1](https://github.com/decred/dcrd/tree/master/dcrec/secp256k1). This is motivated to improve developability (cgo works poorly on arm) and remove performance overhead associated with c bindings.